### PR TITLE
Create an empty non-temporary dictionary for cell configurations

### DIFF
--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -191,7 +191,7 @@
 {
     self = [super init];
     if ( self ) {
-        _cellConfigurations = [NSMutableDictionary dictionary];
+        _cellConfigurations = [[NSMutableDictionary alloc] init];
         _cellSizeCache = [[NSCache alloc] init];
         _cellHeightPadding = kRZCellSizeManagerDefaultCellHeightPadding;
     }


### PR DESCRIPTION
Fix for #14

`[NSMutableDictionary dictionary]` creates a temporary dictionary, which gets autoreleased too early and leads to crashes. `[[NSMutableDictionary alloc] init]` prevents this.
