### PR TITLE
There is a case in iOS8, where we get NSAutoresizingMaskLayoutConstraint...

### DIFF
--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -520,7 +520,7 @@
         {
             [configuration.cell prepareForReuse];
             configuration.configurationBlock(configuration.cell, object);
-            [configuration.cell layoutIfNeeded];
+            [configuration.cell setNeedsLayout];
             UIView* contentView = [configuration.cell contentView];
             height = @([contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize].height + self.cellHeightPadding);
         }


### PR DESCRIPTION
...s, if we have an auto layout cell that uses a custom view using springs and struts.  This crashes the app when we try to re-add the constraint to the custom view, because the NSAutoresizingMaskLayoutConstraints first or second item are nil.  So an additional check to see if the first and second items are nil is performed.
