### PR TITLE
iOS9 trait collection fixes

### DIFF
--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -283,7 +283,7 @@
     if (settableTraitCollectionWindow == nil || [settableTraitCollectionWindow isEqual:[NSNull null]]) {
         settableTraitCollectionWindow = [[SettableTraitCollectionWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
         settableTraitCollectionWindow.settableTraitCollection = self.traitCollection;
-        settableTraitCollectionWindow.windowLevel = -(CGFLOAT_MAX - settableTraitCollectionWindows.count); // for different window levels
+        settableTraitCollectionWindow.windowLevel = -CGFLOAT_MAX + settableTraitCollectionWindows.count; // for different window levels
         settableTraitCollectionWindow.rootViewController = [[UIViewController alloc] init];
         settableTraitCollectionWindow.hidden = NO;
         settableTraitCollectionWindows[self.traitCollection] = settableTraitCollectionWindow;

--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -475,7 +475,6 @@
                 [configuration.cell prepareForReuse];
                 configuration.configurationBlock(configuration.cell, object);
                 UIView* contentView = [configuration.cell contentView];
-                CGSize size;
                 if ( self.overideWidth == 0.0f ) {
                     size = [contentView systemLayoutSizeFittingSize:UILayoutFittingCompressedSize];
                 }

--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -448,8 +448,11 @@
         if ( !self.settableTraitCollectionWindow ) {
             self.settableTraitCollectionWindow = [[SettableTraitCollectionWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
             self.settableTraitCollectionWindow.settableTraitCollection = self.traitCollection;
+            self.settableTraitCollectionWindow.windowLevel = -CGFLOAT_MAX;
+            self.settableTraitCollectionWindow.rootViewController = [[UIViewController alloc] init];
+            self.settableTraitCollectionWindow.hidden = NO;
         }
-        [self.settableTraitCollectionWindow addSubview:cell];
+        [self.settableTraitCollectionWindow.rootViewController.view addSubview:cell];
     }
 }
 

--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -280,7 +280,7 @@
     });
 
     SettableTraitCollectionWindow *settableTraitCollectionWindow = settableTraitCollectionWindows[self.traitCollection];
-    if (settableTraitCollectionWindow == nil || [settableTraitCollectionWindow isEqual:[NSNull null]]) {
+    if (settableTraitCollectionWindow == nil) {
         settableTraitCollectionWindow = [[SettableTraitCollectionWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
         settableTraitCollectionWindow.settableTraitCollection = self.traitCollection;
         settableTraitCollectionWindow.windowLevel = -CGFLOAT_MAX + settableTraitCollectionWindows.count; // for different window levels

--- a/RZCellSizeManager/RZCellSizeManager.m
+++ b/RZCellSizeManager/RZCellSizeManager.m
@@ -286,6 +286,7 @@
         settableTraitCollectionWindow.windowLevel = -(CGFLOAT_MAX - settableTraitCollectionWindows.count); // for different window levels
         settableTraitCollectionWindow.rootViewController = [[UIViewController alloc] init];
         settableTraitCollectionWindow.hidden = NO;
+        settableTraitCollectionWindows[self.traitCollection] = settableTraitCollectionWindow;
     }
 
     return settableTraitCollectionWindow;


### PR DESCRIPTION
- Uses static window to not make a million of them
- Has a dictionary of different traitCollection's windows so throughout the application if it changes we can always have the correct one being used
